### PR TITLE
Add auto-search for set address

### DIFF
--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -144,7 +144,9 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
 
   useImperativeHandle(ref, () => ({
     setAddressText: (address) => {
-      setStateText(address);
+      // set address as search input value and search for it (mar-bi)
+      // setStateText(address);
+      _onChangeText(address);
     },
     getAddressText: () => stateText,
     blur: () => inputRef.current.blur(),


### PR DESCRIPTION
Changes: 
1. Setting the **address string** on the search input will cause an **auto search** for this address (without any necessity for a user's interaction).